### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 # SectionedRecyclerViewAdapter
 
-##About
+## About
 A recyclerView adapter to add sectionned headers
 
 This library is an adaptation of (https://github.com/ragunathjawahar/simple-section-adapter) to be used with a RecyclerView.
 
-##Usage
+## Usage
 ```Java
 //create an adapter
 Youradapter adapter = new Youradapter();


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
